### PR TITLE
Updated the template projects to reflect the current TornadoFX release (1.7.5)

### DIFF
--- a/template-projects/tornadofx-gradle-project/build.gradle
+++ b/template-projects/tornadofx-gradle-project/build.gradle
@@ -1,5 +1,7 @@
 buildscript {
-    ext.kotlin_version = '1.1.0'
+    ext.kotlin_version = '1.1.2'
+
+    compileKotlin.kotlinOptions.jvmTarget = "1.8"
 
     repositories {
         mavenLocal()
@@ -20,7 +22,7 @@ repositories {
 apply plugin: 'application'
 
 dependencies {
-    compile 'no.tornado:tornadofx:1.7.0'
+    compile 'no.tornado:tornadofx:1.7.5'
     testCompile 'junit:junit:4.12'
 }
 

--- a/template-projects/tornadofx-maven-osgi-project/pom.xml
+++ b/template-projects/tornadofx-maven-osgi-project/pom.xml
@@ -8,12 +8,12 @@
     <artifactId>osgidemo</artifactId>
     <name>TornadoFX OSGi Dashboard Application</name>
 
-    <version>1.0</version>
+    <version>1.0.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
     <properties>
-        <kotlin.version>1.1.0</kotlin.version>
-        <tornadofx.version>1.7.0</tornadofx.version>
+        <kotlin.version>1.1.2</kotlin.version>
+        <tornadofx.version>1.7.5</tornadofx.version>
     </properties>
 
     <dependencies>
@@ -55,6 +55,9 @@
                         <goals>
                             <goal>compile</goal>
                         </goals>
+                        <configuration>
+                        <jvmTarget>1.8</jvmTarget>
+                        </configuration>
                     </execution>
                     <execution>
                         <id>test-compile</id>

--- a/template-projects/tornadofx-maven-project/pom.xml
+++ b/template-projects/tornadofx-maven-project/pom.xml
@@ -6,12 +6,12 @@
 
     <groupId>com.example</groupId>
     <artifactId>demo</artifactId>
-    <version>1.0</version>
+    <version>1.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>
-        <kotlin.version>1.1.0</kotlin.version>
-        <tornadofx.version>1.7.0</tornadofx.version>
+        <kotlin.version>1.1.2</kotlin.version>
+        <tornadofx.version>1.7.5</tornadofx.version>
     </properties>
 
     <dependencies>
@@ -47,6 +47,9 @@
                         <goals>
                             <goal>compile</goal>
                         </goals>
+                        <configuration>
+                        <jvmTarget>1.8</jvmTarget>
+                        </configuration>
                     </execution>
                     <execution>
                         <id>test-compile</id>


### PR DESCRIPTION
* Updated the `Kotlin` dependencies to 1.1.2
* Updated the `TornadoFX` dependencies to 1.7.5
* Defined the `jvmTarget` to 1.8
* Updated `pom` file to start with `1.0.0-SNAPSOT` instead of `1.0`

@edvin I don't know much about grandle, so please check if I set the jvmTarget in the right place.
After the the update is released, we should update the `Kotlin` dependency to be 1.1.2-5, so we are in sync with the current `TornadoFx` snapshot.
One more thing do I have to update the zip-files in the resource folder as well?