### PR TITLE
Add quickfix actions for `CssBox`, which simplifies box-statement's

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -75,6 +75,7 @@
         <applicationConfigurable instance="no.tornado.tornadofx.idea.TornadoFXConfigurable" groupId="language" id="preferences.TornadoFX"/>
         <preloadingActivity implementation="no.tornado.tornadofx.idea.FXPreloader"/>
         <annotator language="kotlin" implementationClass="no.tornado.tornadofx.idea.annotator.CSSColorAnnotator" order="first"/>
+        <annotator language="kotlin" implementationClass="no.tornado.tornadofx.idea.annotator.CSSBoxAnnotator" order="first"/>
     </extensions>
 
     <project-components>

--- a/src/no/tornado/tornadofx/idea/FXTools.kt
+++ b/src/no/tornado/tornadofx/idea/FXTools.kt
@@ -18,6 +18,7 @@ class FXTools {
         fun isUIComponent(psiClass: PsiClass) = isType("tornadofx.UIComponent", psiClass)
         fun isApp(psiClass: PsiClass) = isType("tornadofx.App", psiClass)
         fun isView(psiClass: PsiClass) = isType("tornadofx.View", psiClass)
+        fun isStylesheet(psiClass: PsiClass) = isType("tornadofx.Stylesheet", psiClass)
 
         fun isType(type: String, psiClass: PsiClass): Boolean {
             for (supa in psiClass.supers)

--- a/src/no/tornado/tornadofx/idea/annotator/CSSBoxAnnotator.kt
+++ b/src/no/tornado/tornadofx/idea/annotator/CSSBoxAnnotator.kt
@@ -1,0 +1,106 @@
+package no.tornado.tornadofx.idea.annotator
+
+import com.intellij.lang.annotation.AnnotationHolder
+import com.intellij.lang.annotation.Annotator
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
+import no.tornado.tornadofx.idea.FXTools.Companion.isStylesheet
+import no.tornado.tornadofx.idea.quickfixes.css.BoxQuickFix
+import org.jetbrains.kotlin.idea.core.quickfix.QuickFixUtil
+import org.jetbrains.kotlin.idea.references.KtInvokeFunctionReference
+import org.jetbrains.kotlin.idea.references.mainReference
+import org.jetbrains.kotlin.idea.search.allScope
+import org.jetbrains.kotlin.js.descriptorUtils.getJetTypeFqName
+import org.jetbrains.kotlin.psi.KtBinaryExpression
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtNameReferenceExpression
+import org.jetbrains.kotlin.psi.KtProperty
+
+
+/**
+ * Creates an annotation for CssBox statements, if they can be simplified.
+ *
+ * Created by amish on 6/14/17.
+ */
+class CSSBoxAnnotator : Annotator {
+
+    override fun annotate(element: PsiElement, holder: AnnotationHolder) {
+        if (element.isInStylesheetClass()) {
+            if (element is KtBinaryExpression) {
+                val left = element.left
+                if (left is KtNameReferenceExpression) {
+                    val prop = left.mainReference.resolve()
+                    if (prop is KtProperty) {
+                        val returnType = QuickFixUtil.getDeclarationReturnType(prop)
+                        if (returnType?.getJetTypeFqName(false) == "tornadofx.CssBox") {
+                            doAnnotation(element, holder)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun doAnnotation(element: KtBinaryExpression, holder: AnnotationHolder) {
+        val right = element.right?.mainReference
+        if (right is KtInvokeFunctionReference) {
+            val args = right.expression.valueArguments
+            val values = mutableListOf<Pair<Double, String>?>()
+
+            args.forEach { values.add(it.text.convertOrNull()) }
+
+            if (values.isAllSimplifiable()) {
+                holder.createWeakWarningAnnotation(element.right!!.textRange,
+                        "Can be simplified to box(${values[0]!!.first}${values[0]!!.second}).")
+                        .registerFix(BoxQuickFix(element, values[0]!!))
+
+            } else if (values.isVHSimplifiable()) {
+                holder.createWeakWarningAnnotation(element.right!!.textRange,
+                        "Can be simplified to box(${values[0]!!.first}${values[0]!!.second}, ${values[1]!!.first}${values[1]!!.second}).")
+                        .registerFix(BoxQuickFix(element, values[0]!!, values[1]!!))
+            }
+        }
+    }
+
+    private fun String.convertOrNull(): Pair<Double, String>? {
+        with(this) {
+            if (endsWith(".px")) return substringBefore(".px").toDouble() to "px"
+            if (endsWith(".mm")) return substringBefore(".mm").toDouble() to "mm"
+            if (endsWith(".cm")) return substringBefore(".cm").toDouble() to "cm"
+            if (endsWith(".in")) return substringBefore(".in").toDouble() to "in"
+            if (endsWith(".pt")) return substringBefore(".pt").toDouble() to "pt"
+            if (endsWith(".pc")) return substringBefore(".pc").toDouble() to "pc"
+            if (endsWith(".em")) return substringBefore(".em").toDouble() to "em"
+            if (endsWith(".ex")) return substringBefore(".ex").toDouble() to "ex"
+            if (endsWith(".percent")) return substringBefore(".percent").toDouble() to "percent"
+        }
+        return null
+    }
+
+    private fun MutableList<Pair<Double, String>?>.isAllSimplifiable(): Boolean {
+        return this[0]?.first == this[1]?.first && this[0]?.first == this[2]?.first && this[0]?.first == this[3]?.first
+                && this[0]?.second == this[1]?.second && this[0]?.second == this[2]?.second && this[0]?.second == this[3]?.second
+    }
+
+    private fun MutableList<Pair<Double, String>?>.isVHSimplifiable(): Boolean {
+        //top == bottom && right == left
+        return this[0]?.first == this[2]?.first && this[1]?.first == this[3]?.first
+                && this[0]?.second == this[2]?.second && this[1]?.second == this[3]?.second
+    }
+
+    private fun PsiElement.isInStylesheetClass(): Boolean {
+        val psiClass = this.toKtClassOrNull().toPsiClassOrNull()
+        return psiClass != null && isStylesheet(psiClass)
+    }
+
+    private fun PsiElement.toKtClassOrNull(): KtClass? = PsiTreeUtil.getParentOfType(this, KtClass::class.java)
+    private fun KtClass?.toPsiClassOrNull(): PsiClass? = if (this != null) {
+        val psiFacade = JavaPsiFacade.getInstance(this.project)
+        psiFacade.findClass(this.fqName.toString(), this.project.allScope())
+    } else null
+}
+
+
+

--- a/src/no/tornado/tornadofx/idea/quickfixes/css/BoxQuickFix.kt
+++ b/src/no/tornado/tornadofx/idea/quickfixes/css/BoxQuickFix.kt
@@ -1,0 +1,56 @@
+package no.tornado.tornadofx.idea.quickfixes.css
+
+import com.intellij.codeInsight.intention.impl.BaseIntentionAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiFile
+import org.jetbrains.kotlin.psi.KtBinaryExpression
+import org.jetbrains.kotlin.psi.KtPsiFactory
+
+/**
+ * Creates a quick fix for an [CssBox] element that can be simplified.
+ * The following quick fix options are supported.
+ *
+ * box(10.0.px, 10.0.px, 10.0.px, 10.0.px) -> box(10.px)
+ * box(5.px, 10.px, 5.px, 10.px) -> box(5.px, 10.px)
+ * Created by amish on 6/14/17.
+ */
+
+class BoxQuickFix private constructor(val element: KtBinaryExpression, val isSimplifyAll: Boolean): BaseIntentionAction() {
+
+    var all: Pair<Double, String>? = null
+    var vertical: Pair<Double, String>? = null
+    var horizontal: Pair<Double, String>? = null
+
+    constructor(element: KtBinaryExpression, all: Pair<Double, String>): this(element, true) {
+        this.all = all
+    }
+
+    constructor(element: KtBinaryExpression, vertical: Pair<Double, String>, horizontal: Pair<Double, String>): this(element, false) {
+        this.vertical = vertical
+        this.horizontal = horizontal
+    }
+
+    override fun getText(): String {
+        return "Simplify statement..."
+    }
+
+    override fun getFamilyName(): String {
+        return "Simplify statement"
+    }
+
+    override fun isAvailable(p0: Project, p1: Editor?, psiFile: PsiFile?): Boolean {
+        return true
+    }
+
+    override fun invoke(project: Project, editor: Editor?, file: PsiFile?) {
+        val factory = KtPsiFactory(element.project)
+        element.deleteChildInternal(element.right!!.node)
+        val expression = if (all != null) {
+            "box(${all!!.first}.${all!!.second})"
+        } else {
+            "box(${vertical!!.first}.${vertical!!.second}, ${horizontal!!.first}.${horizontal!!.second})"
+        }
+        element.add(factory.createExpression(expression))
+    }
+}


### PR DESCRIPTION
@edvin This can probably be written much nicer, but this is the first time playing with an intellij plugin.
So let me know if I should change something. So far the following simplifications can be done:
* `box(10.px, 10.px, 10.px, 10.px)` -> `box(10.px)`
* `box(10.px, 3.pt, 10.px, 3.pt)` -> `box(10.px, 3.pt)`