### PR TITLE
Resolves #43

### DIFF
--- a/src/no/tornado/tornadofx/idea/annotator/CSSColorAnnotator.kt
+++ b/src/no/tornado/tornadofx/idea/annotator/CSSColorAnnotator.kt
@@ -19,6 +19,7 @@ import org.jetbrains.kotlin.idea.references.mainReference
 import org.jetbrains.kotlin.idea.search.allScope
 import org.jetbrains.kotlin.js.descriptorUtils.getJetTypeFqName
 import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.types.KotlinType
 import java.awt.Color
 import java.util.*
 import javax.swing.Icon
@@ -32,6 +33,7 @@ enum class ColorType {
     RGB_INT_WITHOUT_OPACITY
 }
 
+
 class CSSColorAnnotator : Annotator {
     override fun annotate(element: PsiElement, holder: AnnotationHolder) {
         if (!element.isValid) return
@@ -40,19 +42,33 @@ class CSSColorAnnotator : Annotator {
             val psiFacade = JavaPsiFacade.getInstance(element.project)
             val psiClass = psiFacade.findClass(ktClass.fqName.toString(), element.project.allScope())
             if (psiClass != null && FXTools.isType("tornadofx.Stylesheet", psiClass)) {
-                if (element is KtBinaryExpression) {
-                    val left = element.left
-                    if (left is KtNameReferenceExpression) {
-                        val prop = left.mainReference.resolve()
-                        if (prop is KtProperty) {
-                            val returnType = QuickFixUtil.getDeclarationReturnType(prop)
-                            if (returnType?.getJetTypeFqName(false) == "javafx.scene.paint.Paint") {
-                                annotateColor(element, holder)
+                when (element) {
+                    is KtBinaryExpression -> {
+                        val left = element.left
+                        if (left is KtNameReferenceExpression) {
+                            val prop = left.mainReference.resolve()
+                            if (prop is KtProperty) {
+                                if (prop.declarationReturnType().isFxColor()) annotateColor(element, holder)
                             }
                         }
                     }
+                    is KtProperty -> if (element.declarationReturnType().isFxColor()) annotateColor(element, holder)
                 }
             }
+        }
+    }
+
+    private fun annotateColor(element: KtProperty, holder: AnnotationHolder) {
+        val annotation = holder.createInfoAnnotation(element, null)
+
+        val args = ((element.children.last() as KtElement) as KtCallExpression).valueArguments
+
+        val (fxColor, colorType) = args.toColorType() ?: return
+
+        try {
+            val color = Color(fxColor.red.toFloat(), fxColor.green.toFloat(), fxColor.blue.toFloat(), fxColor.opacity.toFloat())
+            annotation.gutterIconRenderer = PickerRenderer(color, colorType, { element.replaceColor(it) })
+        } catch (ignored: Exception) {
         }
     }
 
@@ -62,56 +78,69 @@ class CSSColorAnnotator : Annotator {
         if (right is KtInvokeFunctionReference && right.expression.isValid) {
             
             val args = right.expression.valueArguments
-            val fxColor: javafx.scene.paint.Color
-            val colorType: ColorType
-            when (args.size) {
-                1, 2 -> {
-                    val colorCode = args[0].textReplace("\"", "")
-                    try {
-                        fxColor = javafx.scene.paint.Color.web(colorCode, args.getOrNull(1)?.textToDouble() ?: 1.0)
-                    } catch (e: IllegalArgumentException) {
-                        // No valid web color so we just show no color annotation
-                        return
-                    }
-                    colorType = if (args.size == 1) ColorType.WEB_WITHOUT_OPACITY else ColorType.WEB_WITHOUT_OPACITY
-                }
-                3, 4 -> {
-                    if (args[0].textContains('.')) {
-                        try {
-                            fxColor = args.floatToColor()
-                        } catch (e: Exception) {
-                            // One of the arguments is bigger the 1.0 or negative, so wie will not show an annotation.
-                            return
-                        }
-                        colorType = if (args.size == 4) ColorType.RGB_DOUBLE_WITH_OPACITY else ColorType.RGB_DOUBLE_WITHOUT_OPACITY
-                    } else {
-                        try {
-                            fxColor = args.intToColor()
-                        } catch (ignored: Exception) {
-                            // One of the arguments is is not a integer, bigger then 255 or negative, so wie will not show an annotation.
-                            return
-                        }
-                        colorType = if (args.size == 4) ColorType.RGB_INT_WITH_OPACITY else ColorType.RGB_INT_WITHOUT_OPACITY
-                    }
-                }
-                else -> return
-            }
-
+            val (fxColor, colorType) = args.toColorType() ?: return
             try {
                 val color = Color(fxColor.red.toFloat(), fxColor.green.toFloat(), fxColor.blue.toFloat(), fxColor.opacity.toFloat())
-                annotation.gutterIconRenderer = PickerRenderer(element, color, colorType)
+                annotation.gutterIconRenderer = PickerRenderer(color, colorType, { element.replaceColor(it) })
             } catch (ignored: Exception) {
             }
         }
     }
 
-    private fun MutableList<KtValueArgument>.floatToColor() =
+    private fun KtNamedDeclaration.declarationReturnType() = QuickFixUtil.getDeclarationReturnType(this)
+    private fun KotlinType?.isFxColor(): Boolean {
+        val fqName = this?.getJetTypeFqName(false)
+        return fqName == "javafx.scene.paint.Color" || fqName == "javafx.scene.paint.Paint"
+    }
+
+    private fun List<KtValueArgument>.toColorType(): Pair<javafx.scene.paint.Color, ColorType>? {
+        when (size) {
+            1, 2 -> {
+                val colorCode = this[0].textReplace("\"", "")
+                val fxColor: javafx.scene.paint.Color
+                try {
+                    fxColor = javafx.scene.paint.Color.web(colorCode, this.getOrNull(1)?.textToDouble() ?: 1.0)
+                } catch (e: IllegalArgumentException) {
+                    // No valid web color so we just show no color annotation
+                    return null
+                }
+                val colorType = if (this.size == 1) ColorType.WEB_WITHOUT_OPACITY else ColorType.WEB_WITHOUT_OPACITY
+                return fxColor to colorType
+            }
+            3, 4 -> {
+                if (this[0].textContains('.')) {
+                    val fxColor: javafx.scene.paint.Color
+                    try {
+                        fxColor = this.floatToColor()
+                    } catch (e: Exception) {
+                        // One of the arguments is bigger the 1.0 or negative, so wie will not show an annotation.
+                        return null
+                    }
+                    val colorType = if (this.size == 4) ColorType.RGB_DOUBLE_WITH_OPACITY else ColorType.RGB_DOUBLE_WITHOUT_OPACITY
+                    return fxColor to colorType
+                } else {
+                    val fxColor: javafx.scene.paint.Color
+                    try {
+                        fxColor = this.intToColor()
+                    } catch (ignored: Exception) {
+                        // One of the arguments is is not a integer, bigger then 255 or negative, so wie will not show an annotation.
+                        return null
+                    }
+                    val colorType = if (this.size == 4) ColorType.RGB_INT_WITH_OPACITY else ColorType.RGB_INT_WITHOUT_OPACITY
+                    return fxColor to colorType
+                }
+            }
+            else -> return null
+        }
+    }
+
+    private fun List<KtValueArgument>.floatToColor() =
             javafx.scene.paint.Color.color(this[0].textToDouble(), //
                     this[1].textToDouble(), //
                     this[2].textToDouble(), //
                     if (this.size == 4) this[3].textToDouble() else 1.0) //
 
-    private fun MutableList<KtValueArgument>.intToColor() =
+    private fun List<KtValueArgument>.intToColor() =
             javafx.scene.paint.Color.rgb(this[0].textToInt(), //
                     this[1].textToInt(), //
                     this[2].textToInt(), //
@@ -122,48 +151,33 @@ class CSSColorAnnotator : Annotator {
     private fun KtValueArgument.textReplace(pattern: String, replacment: String) = text.replace(pattern, replacment)
 
 
-    class PickerRenderer(val element: PsiElement, val currentColor: Color, val colorType: ColorType) : GutterIconRenderer() {
-        override fun getIcon(): Icon {
-            return ColorIcon(16, currentColor)
-        }
+    class PickerRenderer(val currentColor: Color, val colorType: ColorType, val transformer: (String) -> Unit) : GutterIconRenderer() {
 
-        override fun hashCode(): Int {
-            var result = element.hashCode()
-            result = 31 * result + currentColor.hashCode()
-            return result
-        }
-
-        override fun equals(other: Any?): Boolean {
-            return element == other
-        }
+        override fun getIcon(): Icon = ColorIcon(16, currentColor)
 
         override fun getClickAction() = object : AnAction() {
             override fun actionPerformed(e: AnActionEvent) {
                 val editor = CommonDataKeys.EDITOR.getData(e.dataContext)
                 if (editor != null) {
-                    val color = ColorPicker.showDialog(editor.component, "Choose Color", currentColor, true, null, false)
-                    if (color != null) {
-                        ApplicationManager.getApplication()                                       //
-                                .runWriteAction { setColor(element, color, colorType) } //
+                    val color = ColorPicker.showDialog(editor.component, "Choose Color",
+                            currentColor, true, null, false)
+
+                    color?.let {
+                        val colorExpression = it.transform(colorType)
+                        ApplicationManager.getApplication()
+                                .runWriteAction { transformer(colorExpression) }
                     }
                 }
             }
         }
 
-        private fun setColor(element: PsiElement, color: Color, colorType: ColorType) {
-            val factory = KtPsiFactory(element.project)
-            if (element is KtBinaryExpression) {
-                element.deleteChildInternal(element.right!!.node)
-                val expression = when (colorType) {
-                    ColorType.WEB_WITH_OPACITY -> if (color.alpha == 255) color.toWeb() else color.toWebWithOpacity()
-                    ColorType.WEB_WITHOUT_OPACITY -> if (color.alpha == 255) color.toWeb() else color.toWebWithOpacity()
-                    ColorType.RGB_DOUBLE_WITH_OPACITY -> if (color.alpha == 255) color.toRGBDoubleWithoutOpacity() else color.toRGBDoubleWithOpacity()
-                    ColorType.RGB_DOUBLE_WITHOUT_OPACITY -> if (color.alpha == 255) color.toRGBDoubleWithoutOpacity() else color.toRGBDoubleWithOpacity()
-                    ColorType.RGB_INT_WITH_OPACITY -> if (color.alpha == 255) color.toRGBIntWithoutOpacity() else color.toRGBIntWithOpacity()
-                    ColorType.RGB_INT_WITHOUT_OPACITY -> if (color.alpha == 255) color.toRGBIntWithoutOpacity() else color.toRGBIntWithOpacity()
-                }
-                element.add(factory.createExpression(expression))
-            }
+        private fun Color.transform(colorType: ColorType) = when (colorType) {
+            ColorType.WEB_WITH_OPACITY -> if (alpha == 255) toWeb() else toWebWithOpacity()
+            ColorType.WEB_WITHOUT_OPACITY -> if (alpha == 255) toWeb() else toWebWithOpacity()
+            ColorType.RGB_DOUBLE_WITH_OPACITY -> if (alpha == 255) toRGBDoubleWithoutOpacity() else toRGBDoubleWithOpacity()
+            ColorType.RGB_DOUBLE_WITHOUT_OPACITY -> if (alpha == 255) toRGBDoubleWithoutOpacity() else toRGBDoubleWithOpacity()
+            ColorType.RGB_INT_WITH_OPACITY -> if (alpha == 255) toRGBIntWithoutOpacity() else toRGBIntWithOpacity()
+            ColorType.RGB_INT_WITHOUT_OPACITY -> if (alpha == 255) toRGBIntWithoutOpacity() else toRGBIntWithOpacity()
         }
 
         private fun Color.toWebWithOpacity() = """c("#${Integer.toString(red, 16)}${Integer.toString(green, 16)}${Integer.toString(blue, 16)}", %.2f)""".format(Locale.US, alpha.toDouble() / 255.0)
@@ -173,5 +187,38 @@ class CSSColorAnnotator : Annotator {
         private fun Color.toRGBDoubleWithOpacity() = "c(%.2f, %.2f, %.2f, %.2f)".format(Locale.US, red / 255.0, green / 255.0, blue / 255.0, alpha.toDouble() / 255.0)
         private fun Color.toRGBDoubleWithoutOpacity() = "c(%.2f, %.2f, %.2f)".format(Locale.US, red / 255.0, green / 255.0, blue / 255.0)
 
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
+
+            other as PickerRenderer
+
+            if (currentColor != other.currentColor) return false
+            if (colorType != other.colorType) return false
+            if (transformer != other.transformer) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            var result = 31 * currentColor.hashCode()
+            result = 31 * result + colorType.hashCode()
+            result = 31 * result + transformer.hashCode()
+            return result
+        }
+
     }
+
+    private fun KtBinaryExpression.replaceColor(color: String) {
+        val factory = KtPsiFactory(project)
+        deleteChildInternal(right!!.node)
+        add(factory.createExpression(color))
+    }
+
+    private fun KtProperty.replaceColor(color: String) {
+        val factory = KtPsiFactory(project)
+        deleteChildInternal(children.last().node)
+        add(factory.createExpression(color))
+    }
+
 }


### PR DESCRIPTION
At the moment I only check for `c(some color)` in `Stylesheets`, it might make sense to add support color annotations across any Kotlin file?