### PR TITLE
Fix persisting Main class

### DIFF
--- a/src/main/java/no/tornado/tornadofx/idea/configurations/TornadoFXSettingsEditor.java
+++ b/src/main/java/no/tornado/tornadofx/idea/configurations/TornadoFXSettingsEditor.java
@@ -84,11 +84,11 @@ public class TornadoFXSettingsEditor extends SettingsEditor<TornadoFXConfigurati
 		configuration.RUN_TYPE = appButton.isSelected() ? App : View;
 
 		if (configuration.RUN_TYPE == App) {
-			configuration.VIEW_CLASS_NAME = null;
-			configuration.MAIN_CLASS_NAME = getAppClassField().getText();
+			configuration.setViewClassName(null);
+			configuration.setMainClassName(getAppClassField().getText());
 		} else {
-			configuration.VIEW_CLASS_NAME = getViewClassField().getText();
-			configuration.MAIN_CLASS_NAME = "tornadofx.App";
+			configuration.setViewClassName(getViewClassField().getText());
+			configuration.setMainClassName("tornadofx.App");
 		}
 		configuration.LIVE_STYLESHEETS = liveStylesheetsButton.isSelected();
 		configuration.DUMP_STYLESHEETS = dumpStylesheetsButton.isSelected();
@@ -106,12 +106,12 @@ public class TornadoFXSettingsEditor extends SettingsEditor<TornadoFXConfigurati
 			appButton.setSelected(true);
 			appButton.getActionListeners()[0].actionPerformed(null);
 			getViewClassField().setText(null);
-			getAppClassField().setText(configuration.MAIN_CLASS_NAME != null ? configuration.MAIN_CLASS_NAME.replaceAll("\\$", "\\.") : "");
+			getAppClassField().setText(configuration.getMainClassName() != null ? configuration.getMainClassName().replaceAll("\\$", "\\.") : "");
 		} else {
 			viewButton.setSelected(true);
 			viewButton.getActionListeners()[0].actionPerformed(null);
 			getAppClassField().setText(null);
-			getViewClassField().setText(configuration.VIEW_CLASS_NAME != null ? configuration.VIEW_CLASS_NAME.replaceAll("\\$", "\\.") : "");
+			getViewClassField().setText(configuration.getViewClassName() != null ? configuration.getViewClassName().replaceAll("\\$", "\\.") : "");
 		}
 		liveStylesheetsButton.setSelected(configuration.LIVE_STYLESHEETS);
 		dumpStylesheetsButton.setSelected(configuration.DUMP_STYLESHEETS);

--- a/src/main/kotlin/no/tornado/tornadofx/idea/configurations/TornadoFXRunConfigurationProducer.kt
+++ b/src/main/kotlin/no/tornado/tornadofx/idea/configurations/TornadoFXRunConfigurationProducer.kt
@@ -25,11 +25,11 @@ class TornadoFXRunConfigurationProducer : RunConfigurationProducer<TornadoFXConf
 
         if (isApp(psiClass)) {
             configuration.RUN_TYPE = App
-            configuration.MAIN_CLASS_NAME = psiClass.qualifiedName
+            configuration.mainClassName = psiClass.qualifiedName
         } else {
             configuration.RUN_TYPE = View
-            configuration.MAIN_CLASS_NAME = "tornadofx.App"
-            configuration.VIEW_CLASS_NAME = psiClass.qualifiedClassNameForRendering()
+            configuration.mainClassName = "tornadofx.App"
+            configuration.viewClassName = psiClass.qualifiedClassNameForRendering()
         }
         return true
     }


### PR DESCRIPTION
fixes #57

MAIN_CLASS_NAME is deprecated.
setMainClassName() also handles setting it to the options structure which
is used for persisting it into workspace.xml.

Also put VIEW_CLASS_NAME in the options structure, so it matches the
structure of MAIN_CLASS_NAME.
This probably breaks some existing configurations, however since it was
broken anyways, I didn't include legacy-handling.