### PR TITLE
Fix version for distribution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,8 +9,12 @@ version '1.7.17'
 
 
 intellij {
-    version '2018.1.3'
+    version '2018.1'
     plugins = ['Kotlin','properties']
+    patchPluginXml {
+        untilBuild = "" // Be forward compatible
+                        // sinceBuild is inferred from the version above
+    }
 }
 
 publishPlugin {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -16,9 +16,6 @@
     ]]>
     </change-notes>
 
-    <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
-    <idea-version since-build="141.0"/>
-
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html
          on how to target different products -->
 


### PR DESCRIPTION
Turns out I got ourselves a dependency on IDEA 2018.1 when I fixed the run configuration issues without knowing. So while we could overwrite the `sinceBuild` tag, it would crash on older IDEA versions. So let's get this right for now.

When #77 is fixed, this dependency can be loosened again.