### PR TITLE
Also look in the global file for matching translations

### DIFF
--- a/src/main/kotlin/no/tornado/tornadofx/idea/translation/TranslationManager.kt
+++ b/src/main/kotlin/no/tornado/tornadofx/idea/translation/TranslationManager.kt
@@ -58,7 +58,7 @@ class TranslationManager {
     fun findTranslation(key: String, project: Project): String? {
         val values = index.getValues(PropertiesIndex.NAME, key, GlobalSearchScope.allScope(project))
 
-        return values.firstOrNull()
+        return values.firstOrNull() ?: findGlobalTranslation(key, project)
     }
 
     /**
@@ -68,6 +68,11 @@ class TranslationManager {
     fun findTranslation(expression: KtArrayAccessExpression): String? {
         val key = getKey(expression)
         return findTranslation(key, expression.project)
+    }
+
+    private fun findGlobalTranslation(key: String, project: Project): String? {
+        val globalKey = "Messages." + key.substringAfterLast('.')
+        return index.getValues(PropertiesIndex.NAME, globalKey, GlobalSearchScope.allScope(project)).firstOrNull()
     }
 
     fun getResourcePath(project: Project, clazz: KtClass): String {


### PR DESCRIPTION
fixes #92 

However, this does not put new translations into the global file. I think the more likely use-case is to put it into the class-specific files for the quickfix. However, I think a dropdown with possible files would be nice as well.