### PR TITLE
Fix converting (all) properties to TFX Properties

### DIFF
--- a/src/main/kotlin/no/tornado/tornadofx/idea/intentions/ConvertAllPropertiesToFX.kt
+++ b/src/main/kotlin/no/tornado/tornadofx/idea/intentions/ConvertAllPropertiesToFX.kt
@@ -29,7 +29,7 @@ class ConvertAllPropertiesToFX: PsiElementBaseIntentionAction(), LowPriorityActi
 
             val ktClass = if (element is KtClass) element else PsiTreeUtil.getParentOfType(element, KtClass::class.java)
 
-            if (ktClass != null) {
+            if (ktClass != null && !ktClass.isData()) {
                 val psiFacade = JavaPsiFacade.getInstance(project)
                 val psiClass = psiFacade.findClass(ktClass.fqName.toString(), project.allScope())
                 return psiClass != null && !FXTools.isTornadoFXType(psiClass)

--- a/src/main/kotlin/no/tornado/tornadofx/idea/intentions/FXPropertyConverter.kt
+++ b/src/main/kotlin/no/tornado/tornadofx/idea/intentions/FXPropertyConverter.kt
@@ -86,10 +86,10 @@ class FXPropertyConverter : PsiElementBaseIntentionAction(), LowPriorityAction {
 
                 addImports(element, project, importList)
 
-                while(param.nextSibling?.node?.text == "," || param.nextSibling is PsiWhiteSpace)
+                while(param.nextSibling?.node?.text == "," || (param.nextSibling is PsiWhiteSpace && param.nextSibling.nextSibling is PsiWhiteSpace))
                     param.nextSibling.delete()
 
-                while(param.prevSibling?.node?.text == "," || param.prevSibling is PsiWhiteSpace)
+                while(param.prevSibling?.node?.text == "," || (param.prevSibling is PsiWhiteSpace && param.prevSibling.prevSibling is PsiWhiteSpace))
                     param.prevSibling.delete()
 
                 param.delete()
@@ -139,7 +139,9 @@ class FXPropertyConverter : PsiElementBaseIntentionAction(), LowPriorityAction {
         fun createAlternativePropertyElements(factory: KtPsiFactory, paramName: String, returnType: KotlinType, value: String, importList: MutableSet<String>): Pair<PsiElement, PsiElement> {
             val typeName = (returnType.nameIfStandardType ?: returnType.lowerIfFlexible()).toString().replace(Regex("\\?$"), "")
 
-            val propType = when (typeName) {
+            val propType = if (typeName != "String" && returnType.isMarkedNullable) {
+                "SimpleObjectProperty<$typeName>" // SimpleTYPEProperty on primitive types do not support null.
+            } else when (typeName) {
                 "Int" -> "SimpleIntegerProperty"
                 "Long" -> "SimpleLongProperty"
                 "Boolean" -> "SimpleBooleanProperty"


### PR DESCRIPTION
I don't know why, but removing the whitespace will sometimes result
in an endless loop always getting a new PsiWhitespace object.

nullable primitive objects need to be SimpleObjectProperties as
the primitive counterpart do not support null.

Lastly, disable "convert all properties to TFX properties" in data classes
as that would result in an empty constructor which is not allowed
for data classes. It would break the data classes functions anyway.

We might want to consider improving the intention action to keep
constructor parameters so the user of that class can create an object
in the same way it was before running this action. Right now we remove the
parameters.
I still think it's wrong for data classes though

fixes #96